### PR TITLE
8.2 Support: Adds BfA Pathfinder rank 2, Nazjatar and Mechagon

### DIFF
--- a/BeStride_Constants.lua
+++ b/BeStride_Constants.lua
@@ -117,6 +117,13 @@ BeStride_Constants = {
 				depends = 34090,
 				level = 825,
 			},
+			[278833] = {
+				name = "Battle for Azeroth Pathfinder",
+				unlocks = "flying",
+				zones = {
+					[1] = "",
+				},
+			},
 		},
 		Flight = {
 			Restricted = {
@@ -127,10 +134,10 @@ BeStride_Constants = {
 						blocked = true,
 					},
 					[875] = {
-						blocked = true,
+						requires = 278833,
 					},
-					[876] = {
-						blocked = true,
+					[876] = {                                                 
+						requires = 278833,
 					},
 					[619] = {
 						requires = 233368,
@@ -157,6 +164,9 @@ BeStride_Constants = {
 					},
 					[122] = {
 						blocked = true,
+					},
+					[1355] = {
+						requires = 278833,
 					},
 				},
 			},


### PR DESCRIPTION
Adds the Battle for Azeroth Pathfinder Rank 2 achievement and indicates
that it unlocks flying for BfA zones, including Nazjatar and Mechagon

(Changes courtesy of Daeymien)