### PR TITLE
Fix BeStride_Mount:Failback() access to settings

### DIFF
--- a/Versions/Common/BeStride_Mount.lua
+++ b/Versions/Common/BeStride_Mount.lua
@@ -52,7 +52,7 @@ end
 
 function BeStride_Mount:Failback()
 	local mounts = {}
-	if BeStride:DBGetSetting("settings.mount.emptyrandom") then
+	if BeStride:DBGetSetting("mount.emptyrandom") then
 		for k,v in pairs(mountTable["master"]) do if self:IsUsable(k) then table.insert(mounts,k) end end
 		
 		if #mounts == 0 then


### PR DESCRIPTION
`settings.` prefix is added by `BeStride:DBGetSetting()` so the setting is not found if aded twice.