### PR TITLE
fix(ActionButton) only call code on press down

### DIFF
--- a/Versions/Common/BeStride_ActionButton.lua
+++ b/Versions/Common/BeStride_ActionButton.lua
@@ -8,7 +8,7 @@ function BeStride:CreateActionButton(buttontype)
 	local name = "BeStride_AB" .. buttontype .. "Mount"
 
 	local br = CreateFrame("Button", name, UIParent, "SecureActionButtonTemplate,ActionButtonTemplate")
-	br:RegisterForClicks("AnyUp", "AnyDown")
+	br:RegisterForClicks("AnyDown")
 	br:SetAttribute("type","macro")
 	br:SetAttribute("macrotext",nil)
 	


### PR DESCRIPTION
PR https://github.com/Bestride/BeStride/pull/192 had the side effect of calling the entire code twice. Once on key press and once on release.

This prevents adding a dismount logic for druids (see https://github.com/Bestride/BeStride/pull/188 and https://github.com/yannlugrin/BeStride/pull/1) and makes the code quite inefficient. Possibly also has some undiscovered side effects. 

From my limited testing, this change works both on Classic and Retail (some confirmation on Retail would be nice).