### PR TITLE
OPie Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ BeStride is a mount manager that has the following functionality
 * Randomly select mount, based on a customizable list
 * Intelligently select between ground, flying, swimming, repair or passenger
 * Intelligently select class specific spells & mounts depending on the situation (druid cat form in combat, priest levitate, paladin divine steed, warlock underwater breating, etc)
-* [OPie](https://www.curseforge.com/wow/addons/opie) Integration
+* [OPie](https://www.townlong-yak.com/addons/opie) Integration
 
 History
 =================

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ BeStride is a mount manager that has the following functionality
 * Randomly select mount, based on a customizable list
 * Intelligently select between ground, flying, swimming, repair or passenger
 * Intelligently select class specific spells & mounts depending on the situation (druid cat form in combat, priest levitate, paladin divine steed, warlock underwater breating, etc)
+* [OPie](https://www.curseforge.com/wow/addons/opie) Integration
 
 History
 =================

--- a/Versions/BeStride_Mainline.xml
+++ b/Versions/BeStride_Mainline.xml
@@ -31,4 +31,5 @@
   <Script file="Mainline\logic.lua"/>
   <Script file="Common\upgrade.lua"/>
   <Script file="Common\bestride.lua"/>
+  <Script file="Common\opie.lua"/>
 </Ui>

--- a/Versions/BeStride_Wrath.xml
+++ b/Versions/BeStride_Wrath.xml
@@ -33,4 +33,5 @@
   <Script file="Wrath\MountTable.lua"/>
   <Script file="Common\upgrade.lua"/>
   <Script file="Common\bestride.lua"/>
+  <Script file="Common\opie.lua"/>
 </Ui>

--- a/Versions/Common/opie.lua
+++ b/Versions/Common/opie.lua
@@ -1,0 +1,36 @@
+local name, addon = ...
+local f = CreateFrame("Frame");
+local L = LibStub("AceLocale-3.0"):GetLocale("BeStride")
+
+-- Basedd off of Opie Rings\Default.lua file
+local function addBeStrideRingToOpie() 
+    local ringname = L["Bindings.Header"]
+    if not (OPie and OPie.CustomRings) then return end
+    local _, major = OPie.GetVersion()
+    if not (major and major == 4) then return end
+
+    OPie.CustomRings:AddDefaultRing(ringname, {
+        {"macrotext", "/click BeStride_ABRegularMount", icon="Interface/Icons/inv_misc_summerfest_brazierorange", fastClick=true},
+        {"macrotext", "/click BeStride_ABPassengerMount", icon="Interface/Icons/inv_misc_stonedragonorange"},
+        {"macrotext", "/click BeStride_ABGroundMount", icon="Interface/Icons/misc_arrowdown"},
+        {"macrotext", "/click BeStride_ABRepairMount", icon="Interface/Icons/trade_blacksmithing"},
+        name=ringname, hotkey="SHIFT-SPACE", _u="OPCBR"
+    })
+end
+
+local function awaitAddonThen(addonName, andThen)
+    if (IsAddOnLoaded(addonName)) then
+        andThen()
+    else
+        f:RegisterEvent("ADDON_LOADED");
+        f:SetScript("OnEvent", function(self, event, arg1)
+            if (event ~= "ADDON_LOADED") then return end
+            if (arg1 ~= addonName) then return end
+            andThen()
+            f:UnregisterEvent("ADDON_LOADED")
+        end
+        )
+    end
+end
+
+awaitAddonThen("OPie", addBeStrideRingToOpie)

--- a/Versions/Common/opie.lua
+++ b/Versions/Common/opie.lua
@@ -3,19 +3,40 @@ local f = CreateFrame("Frame");
 local L = LibStub("AceLocale-3.0"):GetLocale("BeStride")
 
 -- Basedd off of Opie Rings\Default.lua file
-local function addBeStrideRingToOpie() 
+local function addBeStrideRingToOpie()
     local ringname = L["Bindings.Header"]
     if not (OPie and OPie.CustomRings) then return end
     local _, major = OPie.GetVersion()
     if not (major and major == 4) then return end
 
-    OPie.CustomRings:AddDefaultRing(ringname, {
-        {"macrotext", "/click BeStride_ABRegularMount", icon="Interface/Icons/inv_misc_summerfest_brazierorange", fastClick=true},
-        {"macrotext", "/click BeStride_ABPassengerMount", icon="Interface/Icons/inv_misc_stonedragonorange"},
-        {"macrotext", "/click BeStride_ABGroundMount", icon="Interface/Icons/misc_arrowdown"},
-        {"macrotext", "/click BeStride_ABRepairMount", icon="Interface/Icons/trade_blacksmithing"},
-        name=ringname, hotkey="SHIFT-SPACE", _u="OPCBR"
-    })
+    local opieMountRing = {
+        { "macrotext", "/click BeStride_ABRegularMount", icon = "Interface/Icons/inv_misc_summerfest_brazierorange",
+            fastClick = true },
+    }
+
+    -- Passenger 
+    if next(BeStride:DBGet("mounts.passenger")) then tinsert(opieMountRing,
+            { "macrotext", "/click BeStride_ABPassengerMount",
+                icon = BeStride:IsMainline() and "Interface/Icons/inv_misc_stonedragonorange" or
+                    "Interface/Icons/ability_mount_mammoth_black" })
+    end
+
+    -- Ground Mount
+    tinsert(opieMountRing,
+        { "macrotext", "/click BeStride_ABGroundMount",
+            icon = BeStride:IsMainline() and "Interface/Icons/misc_arrowdown" or
+                "Interface/Icons/ability_mount_dreadsteed" })
+
+    -- Repair
+    if next(BeStride:DBGet("mounts.repair")) then tinsert(opieMountRing,
+            { "macrotext", "/click BeStride_ABRepairMount", icon = "Interface/Icons/trade_blacksmithing" })
+    end
+
+    opieMountRing["name"] = ringname
+    opieMountRing["hotkey"] = "SHIFT-SPACE"
+    opieMountRing["u"] = "OPCBR"
+
+    OPie.CustomRings:AddDefaultRing(ringname, opieMountRing)
 end
 
 local function awaitAddonThen(addonName, andThen)


### PR DESCRIPTION
For joint BeStride and [OPie](https://www.townlong-yak.com/addons/opie) users, this adds a default ring to OPie.

![image](https://user-images.githubusercontent.com/20718430/205437083-63b02e27-7e3a-403f-90a0-9266154b0c32.png)

As far as OPie is concerned, this will follow all other "Default" rules that a "Default" OPie ring follows. If you update it, it should automatically update for users (New icons, extra buttons, change the default binding, etc). If they delete it by accident, they can just click OPie's "Defaults" button to regenerate all the default rings again, and so on.