### PR TITLE
fix(df-instance): fixes RegularMount in DF Instances

### DIFF
--- a/Versions/Common/logic.zone.lua
+++ b/Versions/Common/logic.zone.lua
@@ -16,6 +16,16 @@ end
 
 function BeStride:IsDragonRidingZone()
 	if IsOutdoors() then		
+		if IsInInstance() then
+			local instanceID = select(8,GetInstanceInfo())
+			local instancesWithDragonRiding = {
+				[2516]=true, --The Nokhud Offensive
+			}
+			if not instancesWithDragonRiding[instanceID] then 
+				return false
+			end
+		end
+
 		if countTable(BeStride_Constants.Riding.Dragonriding.Restricted.Continents) > 0 then
 			local skill,spells = self:GetRidingSkill()
 			local mapID = C_Map.GetBestMapForUnit("player")


### PR DESCRIPTION
Fixes #233 

Effectively turns Dragonriding off in all DF instanced content except things we whitelist. 

Tested in DF Open world, Brackenhide Hollow (normal mount works), and Nokhud Offensie (Dragonriding works)

Not quite as elegant as your Constants table 🤷🏻 