### PR TITLE
Fix/flyable edge cases

### DIFF
--- a/Versions/Common/BeStride_Constants.lua
+++ b/Versions/Common/BeStride_Constants.lua
@@ -173,9 +173,6 @@ BeStride_Constants = {
 				Worlds = {
 				},
 				Continents = {
-					[113] = {
-						requires = 54197,
-					},
 					[905] = {
 						blocked = true,
 					},

--- a/Versions/Common/Mapping.lua
+++ b/Versions/Common/Mapping.lua
@@ -21,12 +21,7 @@ function BeStride:GetMapUntil(locID,filter,printOut)
 	if map.mapType == filter then
 		return map
 	elseif map.mapType > filter and map.parentMapID ~= nil and map.parentMapID ~= 0 then
-		local parentMap = self:GetMapUntil(map.parentMapID,filter,printOut)
-		if parentMap ~= nil then
-			return parentMap
-		else
-			return map
-		end
+		return self:GetMapUntil(map.parentMapID,filter,printOut) or map
 	else
 		return nil
 	end

--- a/Versions/Common/bestride.lua
+++ b/Versions/Common/bestride.lua
@@ -39,6 +39,10 @@ function BeStride:OnInitialize()
 	playerTable["faction"]["name"] = factionName
 	playerTable["faction"]["id"] = factionId
 	playerTable["faction"]["localization"] = factionLocalized
+
+	if BeStride.OverrideConstants ~= nil then
+		BeStride:OverrideConstants()
+	end
 end
 
 function BeStride:OnEnable()

--- a/Versions/Common/logic.zone.lua
+++ b/Versions/Common/logic.zone.lua
@@ -99,11 +99,13 @@ end
 function BeStride:IsSpecialZone()
 	local mapID = C_Map.GetBestMapForUnit("player")
 	local micro = BeStride:GetMapUntil(mapID,5)
-	local dungeon = BeStride:GetMapUntil(mapID,4)
-	local zone = BeStride:GetMapUntil(mapID,3)
 	local continent = BeStride:GetMapUntil(mapID,2)
+
+	if continent == nil or micro == nil then
+		return false
+	end
 	
-	if continent ~= nil and continent.name == LibStub("AceLocale-3.0"):GetLocale("BeStride")["Continent.Draenor"] and micro.name == LibStub("AceLocale-3.0"):GetLocale("BeStride")["Zone.Nagrand"] and self:DBGet("settings.mount.telaari") == true then
+	if continent.name == LibStub("AceLocale-3.0"):GetLocale("BeStride")["Continent.Draenor"] and micro.name == LibStub("AceLocale-3.0"):GetLocale("BeStride")["Zone.Nagrand"] and self:DBGet("settings.mount.telaari") == true then
 		local garrisonAbilityName = GetSpellInfo(161691)
 		local _,_,_,_,_,_,spellID = GetSpellInfo(garrisonAbilityName)
 		if(spellID == 165803 or spellID == 164222) then

--- a/Versions/Wrath/bestride.lua
+++ b/Versions/Wrath/bestride.lua
@@ -51,3 +51,7 @@ function BeStride:GetMountInfoByIndex(index)
         isForDragonriding = nil
     }
 end
+
+function BeStride:OverrideConstants()
+    BeStride_Constants.Riding.Flight.Restricted.Continents[113].requires = 54197
+end


### PR DESCRIPTION
Fixes #226 and #236 to enable Retail Northrend flying and Draenor Flying when you haven't unlocked the Nagrand zone ability 