### PR TITLE
Fixes #241

### DIFF
--- a/Versions/Wrath/bestride.lua
+++ b/Versions/Wrath/bestride.lua
@@ -53,6 +53,7 @@ function BeStride:GetMountInfoByIndex(index)
 end
 
 function BeStride:OverrideConstants()
+    BeStride_Constants.Riding.Flight.Restricted.Continents[113] = {}
     BeStride_Constants.Riding.Flight.Restricted.Continents[113].requires = 54197
 end
 


### PR DESCRIPTION
Fixes #241 - Adds continent table before attempting to set required spell.