### PR TITLE
Fixes #245 - Block flying in Underbelly

### DIFF
--- a/Versions/Common/BeStride_Constants.lua
+++ b/Versions/Common/BeStride_Constants.lua
@@ -215,6 +215,9 @@ BeStride_Constants = {
 						blocked = true,
 						except = LibStub("AceLocale-3.0"):GetLocale("BeStride")["Zone.Dalaran.SubZone.KrasusLanding"]
 					}
+					[127] = {
+						blocked = true,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Fixes: #245  - Block flying in Underbelly