### PR TITLE
fix(opie): add sliceTokens

### DIFF
--- a/Versions/Common/mount.table.lua
+++ b/Versions/Common/mount.table.lua
@@ -64,7 +64,7 @@ function BeStride:AddCommonMount(mountId)
 			table.insert(mountTable["zone"],mountId)
 		else
 			--local mountID,name,spellID,icon,isSummoned,mountTypeID = GetCompanionInfo("MOUNT", mountId)
-			BeStride_Debug:Debug("Not Adding Mount" .. mount["name"] .. " Id: " .. mountId .. " SpellId: " .. mount.spellID)
+			print("Not Adding Mount" .. mount["name"] .. " Id: " .. mountId .. " SpellId: " .. mount.spellID)
 		end
 	end
 end

--- a/Versions/Common/mount.table.lua
+++ b/Versions/Common/mount.table.lua
@@ -64,7 +64,7 @@ function BeStride:AddCommonMount(mountId)
 			table.insert(mountTable["zone"],mountId)
 		else
 			--local mountID,name,spellID,icon,isSummoned,mountTypeID = GetCompanionInfo("MOUNT", mountId)
-			print("Not Adding Mount" .. mount["name"] .. " Id: " .. mountId .. " SpellId: " .. mount.spellID)
+			BeStride_Debug:Debug("Not Adding Mount" .. mount["name"] .. " Id: " .. mountId .. " SpellId: " .. mount.spellID)
 		end
 	end
 end

--- a/Versions/Common/opie.lua
+++ b/Versions/Common/opie.lua
@@ -10,31 +10,51 @@ local function addBeStrideRingToOpie()
     if not (major and major == 4) then return end
 
     local opieMountRing = {
-        { "macrotext", "/click BeStride_ABRegularMount", icon = "Interface/Icons/inv_misc_summerfest_brazierorange",
-            fastClick = true },
+        {
+            "macrotext",
+            "/click BeStride_ABRegularMount",
+            _u = "d", -- default
+            icon = "Interface/Icons/inv_misc_summerfest_brazierorange",
+            fastClick = true
+        },
     }
 
-    -- Passenger 
-    if next(BeStride:DBGet("mounts.passenger")) then tinsert(opieMountRing,
-            { "macrotext", "/click BeStride_ABPassengerMount",
+    -- Passenger
+    if next(BeStride:DBGet("mounts.passenger")) then
+        tinsert(opieMountRing,
+            {
+                "macrotext",
+                "/click BeStride_ABPassengerMount",
+                _u = "p", -- passenger
                 icon = BeStride:IsMainline() and "Interface/Icons/inv_misc_stonedragonorange" or
-                    "Interface/Icons/ability_mount_mammoth_black" })
+                    "Interface/Icons/ability_mount_mammoth_black"
+            })
     end
 
     -- Ground Mount
     tinsert(opieMountRing,
-        { "macrotext", "/click BeStride_ABGroundMount",
+        {
+            "macrotext",
+            "/click BeStride_ABGroundMount",
+            _u = "g", -- ground
             icon = BeStride:IsMainline() and "Interface/Icons/misc_arrowdown" or
-                "Interface/Icons/ability_mount_dreadsteed" })
+                "Interface/Icons/ability_mount_dreadsteed"
+        })
 
     -- Repair
-    if next(BeStride:DBGet("mounts.repair")) then tinsert(opieMountRing,
-            { "macrotext", "/click BeStride_ABRepairMount", icon = "Interface/Icons/trade_blacksmithing" })
+    if next(BeStride:DBGet("mounts.repair")) then
+        tinsert(opieMountRing,
+            {
+                "macrotext",
+                "/click BeStride_ABRepairMount",
+                _u = "r", -- repair
+                icon = "Interface/Icons/trade_blacksmithing"
+            })
     end
 
     opieMountRing["name"] = ringname
     opieMountRing["hotkey"] = "SHIFT-SPACE"
-    opieMountRing["u"] = "OPCBR"
+    opieMountRing["_u"] = "BSR" -- [B]e[S]t[r]ide
 
     OPie.CustomRings:AddDefaultRing(ringname, opieMountRing)
 end


### PR DESCRIPTION
Fixes #257 

Looks like OPie had some rewrites which makes their sliceTokens (`_u` keys) required (and unique). Currently it's just a deprecation notice, but this should get ahead us out ahead of it.

Also ran VSCode Formatter over the OPie file for some cleanup.